### PR TITLE
Specify explicit integer params

### DIFF
--- a/R/ic_event.R
+++ b/R/ic_event.R
@@ -23,7 +23,7 @@
 ic_event <- function(
   uid = ic_guid(),
   start_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours")),
-  end_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours") + 1 * 60 * 60),
+  end_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours") + 1L * 60L * 60L),
   format = "%Y-%m-%d %H:%M",
   summary = "ical event",
   more_properties = FALSE,

--- a/man/ic_event.Rd
+++ b/man/ic_event.Rd
@@ -7,8 +7,8 @@
 \usage{
 ic_event(uid = ic_guid(),
   start_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours")),
-  end_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours") + 1 *
-  60 * 60), format = "\%Y-\%m-\%d \%H:\%M", summary = "ical event",
+  end_time = as.POSIXct(round.POSIXt(Sys.time(), units = "hours") + 1L *
+  60L * 60L), format = "\%Y-\%m-\%d \%H:\%M", summary = "ical event",
   more_properties = FALSE, event_properties = ical::properties)
 }
 \arguments{


### PR DESCRIPTION
@Robinlovelace @layik This is just a good practice thing. Explicitly specifying integers by changing `1` to `1L` will generally boost efficiency in vectorized operations, because the underlying **C** arrays will be allocated as the appropriate (and faster) type. Without this, they'll be `float`, and this can be less efficient. This is just an example, and there are likely other places whether this would be good to implement